### PR TITLE
allow dgoss to handle yaml files in other directories

### DIFF
--- a/extras/dgoss/README.md
+++ b/extras/dgoss/README.md
@@ -81,3 +81,5 @@ Options to use for the goss wait run, when `./goss_wait.yaml` exists. (Default: 
 ##### GOSS_SLEEP
 Time to sleep after running container (and optionally `goss_wait.yaml`) and before running tests. (Default: `0.2`)
 
+##### GOSS_FILES_PATH
+Location of the goss yaml files. (Default: `.`)

--- a/extras/dgoss/dgoss
+++ b/extras/dgoss/dgoss
@@ -3,6 +3,7 @@
 set -e
 
 USAGE="USAGE: $(basename "$0") [run|edit] <docker_run_params>"
+GOSS_FILES_PATH="${GOSS_FILES_PATH:-.}"
 
 info() { echo -e "INFO: $*"; }
 error() { echo -e "ERROR: $*";exit 1; }
@@ -21,8 +22,8 @@ run(){
     # Copy in goss
     cp "${GOSS_PATH}" "$tmp_dir/goss"
     chmod 755 "$tmp_dir/goss"
-    [[ -e goss.yaml ]] && cp goss.yaml "$tmp_dir"
-    [[ -e goss_wait.yaml ]] && cp goss_wait.yaml "$tmp_dir"
+    [[ -e "${GOSS_FILES_PATH}/goss.yaml" ]] && cp "${GOSS_FILES_PATH}/goss.yaml" "$tmp_dir"
+    [[ -e "${GOSS_FILES_PATH}/goss_wait.yaml" ]] && cp "${GOSS_FILES_PATH}/goss_wait.yaml" "$tmp_dir"
     info "Starting docker container"
     id=$(docker run -d -v "$tmp_dir:/goss" "${@:2}")
     docker logs -f "$id" > "$tmp_dir/docker_output.log" 2>&1 &
@@ -51,7 +52,7 @@ GOSS_SLEEP=${GOSS_SLEEP:-0.2}
 case "$1" in
     run)
         run "$@"
-        if [[ -e goss_wait.yaml ]]; then
+        if [[ -e "${GOSS_FILES_PATH}/goss_wait.yaml" ]]; then
             info "Found goss_wait.yaml, waiting for it to pass before running tests"
             if ! docker exec "$id" sh -c "/goss/goss -g /goss/goss_wait.yaml validate $GOSS_WAIT_OPTS"; then
                 error "goss_wait.yaml never passed"


### PR DESCRIPTION
### Context
Dgoss expects the files in the current directory, I'm building multiple docker images so I need multiple yaml files.

### What has been done
- added a global environment variable (in the same style as the others) to define the location of the yaml files.

### How to test
- move your current yaml file to another directory and run ```GOSS_FILES_PATH=<dir> dgoss run <image>